### PR TITLE
Fixes Issue #1

### DIFF
--- a/libio/serial_com.cpp
+++ b/libio/serial_com.cpp
@@ -154,6 +154,8 @@ size_t SerialCom::readFrame(uint8_t *buf, size_t len)
 		res = read(fd, buf + index, len - index);
 		if (verbose)
 			printf("sc: read result %d \n", res);
+		if (res == 0)
+			throw std::runtime_error(std::string("sc: serial device disconnected"));
 		if (res < 0)
 			throw std::runtime_error(std::string("sc: serial read error"));
 		index += res;

--- a/libio/serial_com.cpp
+++ b/libio/serial_com.cpp
@@ -154,7 +154,7 @@ size_t SerialCom::readFrame(uint8_t *buf, size_t len)
 		res = read(fd, buf + index, len - index);
 		if (verbose)
 			printf("sc: read result %d \n", res);
-		if (res == 0)
+		if (res == 0)  // zero bytes read (after successful pselect) indicates disconnected device
 			throw std::runtime_error(std::string("sc: serial device disconnected"));
 		if (res < 0)
 			throw std::runtime_error(std::string("sc: serial read error"));

--- a/libio/serial_protocol.cpp
+++ b/libio/serial_protocol.cpp
@@ -442,7 +442,7 @@ void SerialProtocolBase::parse_sensor_args()
   {
     std::cout << " sensor_args dictionary" << std::endl;
     for(auto const& p: args_dict)
-      std::cout << ' {' << p.first << " => " << p.second << '}' << '\n';
+      std::cout << " {" << p.first << " => " << p.second << "}" << '\n';
   }
 }
 

--- a/libio/serial_protocol.cpp
+++ b/libio/serial_protocol.cpp
@@ -630,7 +630,11 @@ bool SerialProtocolBase::init_device_from_config(uint8_t* buf, const uint8_t con
       }
     }
     else
+    {
+      if (verbose)
+        printf("sp: no sensor driver found for sensor %d\n", i);
       return false;
+    }
   }
   return true;
 }

--- a/libio/serial_protocol.cpp
+++ b/libio/serial_protocol.cpp
@@ -609,7 +609,7 @@ bool SerialProtocolBase::init_device_from_config(uint8_t* buf, const uint8_t con
     uint16_t sen_type = config_buf[0] + config_buf[1] * 256;
     uint16_t sen_len = config_buf[2] + config_buf[3] * 256;
     if (verbose)
-      printf("sp: for sensor %d, found sen_type %u and sen_len %u\n", i, sen_type, sen_len);
+      printf("sp: for sensor %d, found sen_type %04X and sen_len %u\n", i, sen_type, sen_len);
     if (exists_sensor_driver(sen_type))
     {
       try
@@ -631,8 +631,7 @@ bool SerialProtocolBase::init_device_from_config(uint8_t* buf, const uint8_t con
     }
     else
     {
-      if (verbose)
-        printf("sp: no sensor driver found for sensor %d\n", i);
+      printf("sp: no sensor driver found for logical sensor %d with type %04X, check registred_devices.yaml\n", i, sen_type);
       return false;
     }
   }
@@ -1105,7 +1104,9 @@ void SerialProtocolBase::read_config(uint8_t* buf)
   // create a device
   if (!set_device(buf[SP_DEVID_OFFSET]))
   {
-    throw std::runtime_error(std::string("sp: device exists already"));
+    std::cerr << "sp:device with id " << (int)buf[SP_DEVID_OFFSET] 
+              << " is not a known device type (check device_types.yaml)" << std::endl;
+    throw std::runtime_error(std::string("sp: device type not found"));
   }
 
   // get how much more config comes


### PR DESCRIPTION
According to the doc with help of [stackoverflow forum](https://stackoverflow.com/questions/34170350/detecting-if-a-character-device-has-disconnected-in-linux-in-with-termios-api-c) to understand it, it seems that catching a closed port is not possible through `pselect` (file descriptor is actually still ready) because the file descriptor remains open, even if it does not exist anymore at system side.
However any `read` will result in 0 bytes. Hence using a zero read to detect a disconnected port is the solution.
The standard no data to stream error if the device does not write, is still caught by the `pselect` timeout.

The main change of this PR is to immediately detect a disconnected port and hence help reconnect on the same port (port is closed cleanly immediately at disconnection)

Additional commits help identify other errors but introduce not behaviour change, hence included in this PR

This change was tested on a glove an iObject+ and a TactileFingertip mockup (not with myrmex but should not be a problem)