### PR TITLE
Fix connection issues after crash

### DIFF
--- a/libio/serial_com.cpp
+++ b/libio/serial_com.cpp
@@ -53,16 +53,8 @@ SerialCom::~SerialCom() {
 
 void SerialCom::setTimeOut(unsigned int msec)
 {
-	if (msec >= 1000)
-	{
-		timeout.tv_sec = msec/1000;
-		timeout.tv_nsec = (msec%1000) * 1e6;
-	}
-	else
-	{
-		timeout.tv_sec = 0;
-		timeout.tv_nsec = msec * 1e6;
-	}
+	timeout.tv_sec = msec / 1000;
+	timeout.tv_nsec = (msec % 1000) * 1e6;
 }
 
 void SerialCom::connect(const std::string &sDevice)

--- a/libio/serial_com.cpp
+++ b/libio/serial_com.cpp
@@ -111,7 +111,6 @@ void SerialCom::connect(const std::string &sDevice)
 	FD_SET (fd,&fdset);
 
 	connected = true;
-  flush();
 }
 
 void SerialCom::disconnect()

--- a/libio/serial_com.cpp
+++ b/libio/serial_com.cpp
@@ -192,7 +192,7 @@ void SerialCom::flush(const std::chrono::milliseconds &timeout)
 	catch (const std::exception &e) {
 		std::cerr << e.what() << std::endl;
 	}
-	if (now >= deadline)
+	if (len == sizeof(buf))
 		throw std::runtime_error("Device didn't stop streaming. Try to disconnect and reconnect.");
 }
 

--- a/libio/serial_com.cpp
+++ b/libio/serial_com.cpp
@@ -186,15 +186,15 @@ size_t SerialCom::write(const uint8_t *buf, size_t len)
 void SerialCom::flush()
 {
 	unsigned char buf[256];
-	size_t read_len;
+	size_t len = sizeof(buf);
 	try{
-		read_len = read(buf, 256); // read possibly incomplete frame
+		// read remaining buffer
+		while (len == sizeof(buf))
+			len = read(buf, sizeof(buf));
 	}
 	catch (const std::exception &e) {
 		std::cerr << e.what() << std::endl;
 	}
-	if (verbose)
-		printf("sc: flushed %lu chars\n", read_len);
 }
 
 }

--- a/libio/serial_com.cpp
+++ b/libio/serial_com.cpp
@@ -193,7 +193,7 @@ void SerialCom::flush(const std::chrono::milliseconds &timeout)
 		std::cerr << e.what() << std::endl;
 	}
 	if (len == sizeof(buf))
-		throw std::runtime_error("Device didn't stop streaming. Try to disconnect and reconnect.");
+		throw std::runtime_error("flush() failed. Device is still streaming.");
 }
 
 }

--- a/libio/serial_com.h
+++ b/libio/serial_com.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <exception>
 #include <string>
-
+#include <chrono>
 
 namespace serial_protocol {
 class SerialCom
@@ -47,7 +47,7 @@ public:
 	void setVerbose(bool verb) { verbose = verb; }
 	void connect(const std::string &sDevice);
 	void disconnect();
-	void flush();
+	void flush(const std::chrono::milliseconds &timeout = std::chrono::seconds(1));
 	size_t read (uint8_t *buf, size_t len);
 	size_t write (const uint8_t *buf, size_t len);
 


### PR DESCRIPTION
When the device was not correctly closed (i.e. stopping streaming beforehand), a new connection attempt may result in errors because the serial read buffer was not fully flushed before attempting to configure the device. 
Actually, this behavior was reproducible with Myrmex v2 by killing the SP driver node instead of using Ctrl-C to quit.

This PR changes `flush()` to read _all_ content of the read buffer (after stopping streaming). Successfully tested on Myrmex v2.
@llach